### PR TITLE
Remove arg used only for logging

### DIFF
--- a/skxray/core/fitting/xrf_model.py
+++ b/skxray/core/fitting/xrf_model.py
@@ -1258,19 +1258,17 @@ def fit_per_line_nnls(data, matv, param, use_snip):
     """
     out = []
     bg_sum = 0
-    for i in range(data.shape[0]):
-        if use_snip is True:
-            bg = snip_method(data[i, :],
+    for y in data:
+        if use_snip:
+            bg = snip_method(y,
                              param['e_offset']['value'],
                              param['e_linear']['value'],
                              param['e_quadratic']['value'],
                              width=param['non_fitting_values']['background_width'])
-            y = data[i, :] - bg
             bg_sum = np.sum(bg)
-
+            result, res = nnls_fit(y - bg, matv, weights=None)
         else:
-            y = data[i, :]
-        result, res = nnls_fit(y, matv, weights=None)
+            result, res = nnls_fit(y - bg, matv, weights=None)
 
         sst = np.sum((y-np.mean(y))**2)
         r2 = 1 - res/sst
@@ -1310,22 +1308,19 @@ def fit_pixel_multiprocess_nnls(exp_data, matv, param,
 
     Returns
     -------
-    dict :
-        fitting values for all the elements
+    array
+        Fitting values for all the elements
     """
     num_processors_to_use = multiprocessing.cpu_count()
 
     logger.info('cpu count: {}'.format(num_processors_to_use))
     pool = multiprocessing.Pool(num_processors_to_use)
 
-    result_pool = [pool.apply_async(_log_and_fit,
-                                    (n, exp_data[n, :, :], matv,
-                                     param, use_snip))
-                   for n in range(exp_data.shape[0])]
+    result_pool = [
+        pool.apply_async(_log_and_fit, (n, data, matv,param, use_snip))
+        for n, data in enumerate(exp_data)]
 
-    results = []
-    for r in result_pool:
-        results.append(r.get())
+    results = [r.get() for r in result_pool]
 
     pool.terminate()
     pool.join()

--- a/skxray/core/fitting/xrf_model.py
+++ b/skxray/core/fitting/xrf_model.py
@@ -1236,14 +1236,11 @@ def _get_activated_line(incident_energy, elemental_line):
         return line_list
 
 
-def fit_per_line_nnls(row_num, data,
-                      matv, param, use_snip):
-    """
-    Fit experiment data for a given row using nnls algorithm.
+def fit_per_line_nnls(data, matv, param, use_snip):
+    """Fit experiment data for a given row using nnls algorithm.
+
     Parameters
     ----------
-    row_num : int
-        which row to fit
     data : array
         selected one row of experiment spectrum
     matv : array
@@ -1259,7 +1256,6 @@ def fit_per_line_nnls(row_num, data,
         fitting values for all the elements at a given row. Background is
         calculated as a summed value. Also residual is included.
     """
-    logger.info('Row number at {}'.format(row_num))
     out = []
     bg_sum = 0
     for i in range(data.shape[0]):
@@ -1283,6 +1279,19 @@ def fit_per_line_nnls(row_num, data,
     return np.array(out)
 
 
+def _log_and_fit(row_num, *args):
+    """Wrapper around fit_per_line_nnls to log the row num that is being used
+
+    Parameters
+    ----------
+    row_num : int
+        The row number that is being computed
+    args
+        The arguments to `fit_per_line_nnls`
+    """
+    logger.info('Row number at {}'.format(row_num))
+    return fit_per_line_nnls(*args)
+
 def fit_pixel_multiprocess_nnls(exp_data, matv, param,
                                 use_snip=False):
     """
@@ -1290,7 +1299,7 @@ def fit_pixel_multiprocess_nnls(exp_data, matv, param,
     Parameters
     ----------
     exp_data : array
-        3D data of experiment spectrum, 
+        3D data of experiment spectrum,
         with x,y positions as the first 2-dim, and energy as the third one.
     matv : array
         matrix for regression analysis
@@ -1309,7 +1318,7 @@ def fit_pixel_multiprocess_nnls(exp_data, matv, param,
     logger.info('cpu count: {}'.format(num_processors_to_use))
     pool = multiprocessing.Pool(num_processors_to_use)
 
-    result_pool = [pool.apply_async(fit_per_line_nnls,
+    result_pool = [pool.apply_async(_log_and_fit,
                                     (n, exp_data[n, :, :], matv,
                                      param, use_snip))
                    for n in range(exp_data.shape[0])]


### PR DESCRIPTION
Li,

I am not a fan of a function that accepts an argument only for the purposes of logging.  That being said, I definitely see why you want the functionality!  I removed that argument from the scientific function `fit_per_line_nnls`, but kept the overall functionality by adding a wrapper function `_log_and_fit`.  That way, the `fit_per_line_nnls` can still be called from somewhere else in the library, but the multiprocessing pixel fitting is still usable and logs to the screen.  Super useful addition!  Thanks for working on this.

Thoughts?
